### PR TITLE
Better design of the Emitter

### DIFF
--- a/.github/workflows/run-go-test.yml
+++ b/.github/workflows/run-go-test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.4
+          go-version: 1.22.4
 
       # Prints some relevant information
       - run: echo "repository is ${{ github.repository }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 results
 data
+backup
 *.pprof
 
 # Binaries for programs and plugins

--- a/cmd/lp-cc/cc_test.go
+++ b/cmd/lp-cc/cc_test.go
@@ -66,7 +66,7 @@ func TestDynamicCreation(t *testing.T) {
 
 		t.Log("TestDynamicCreation ", count, " t ", threads)
 
-		rawTestGraph := []graph.TopologyEvent[EdgeProperty]{
+		rawTestGraph := []graph.InputEvent[EdgeProperty]{
 			{TypeAndEventIdx: uint64(graph.ADD), SrcRaw: graph.AsRawType(1), DstRaw: graph.AsRawType(4)},
 			{TypeAndEventIdx: uint64(graph.ADD), SrcRaw: graph.AsRawType(7), DstRaw: graph.AsRawType(0)},
 			{TypeAndEventIdx: uint64(graph.ADD), SrcRaw: graph.AsRawType(2), DstRaw: graph.AsRawType(1)},

--- a/cmd/lp-colouring/colouring_test.go
+++ b/cmd/lp-colouring/colouring_test.go
@@ -48,7 +48,7 @@ func TestAsyncDynamic(t *testing.T) {
 
 func TestAsyncDynamicWithDelete(t *testing.T) {
 	for ti := 0; ti < 10; ti++ {
-		rawStructureChanges := []graph.TopologyEvent[EdgeProperty]{
+		rawStructureChanges := []graph.InputEvent[EdgeProperty]{
 			{TypeAndEventIdx: uint64(graph.ADD), SrcRaw: graph.AsRawType(1), DstRaw: graph.AsRawType(4), EdgeProperty: EdgeProperty{}},
 			{TypeAndEventIdx: uint64(graph.ADD), SrcRaw: graph.AsRawType(2), DstRaw: graph.AsRawType(0), EdgeProperty: EdgeProperty{}},
 			{TypeAndEventIdx: uint64(graph.ADD), SrcRaw: graph.AsRawType(2), DstRaw: graph.AsRawType(1), EdgeProperty: EdgeProperty{}},

--- a/cmd/lp-pagerank/correctness.go
+++ b/cmd/lp-pagerank/correctness.go
@@ -36,9 +36,10 @@ func PrintTopN(g *graph.Graph[VertexProperty, EdgeProperty, Mail, Note], size ui
 		log.Info().Msg(interestStr)
 	} else {
 		log.Info().Msg("Top N:")
-		log.Info().Msg("pos,   rawId,           score")
+		log.Info().Msg("pos,   rawId,           score,    thread,  threadInternalVidx")
 		for i := uint32(0); i < topN; i++ {
-			log.Info().Msg(utils.V(i) + "," + utils.F("%10s", g.NodeVertexRawID(vIds[res[i].First]).String()) + "," + utils.F("%16.6f", res[i].Second))
+			idx, tidx := graph.InternalExpand(vIds[res[i].First])
+			log.Info().Msg(utils.V(i) + "," + utils.F("%10s", g.NodeVertexRawID(vIds[res[i].First]).String()) + "," + utils.F("%16.6f", res[i].Second) + "," + utils.F("%5d", tidx) + "," + utils.F("%14d", idx))
 		}
 	}
 }

--- a/cmd/lp-pagerank/pagerank_test.go
+++ b/cmd/lp-pagerank/pagerank_test.go
@@ -59,7 +59,7 @@ func DynamicCreation(undirected bool, t *testing.T) {
 
 		t.Log("TestDynamicCreation ", tCount, " t ", THREADS)
 
-		rawTestGraph := []graph.TopologyEvent[EdgeProperty]{
+		rawTestGraph := []graph.InputEvent[EdgeProperty]{
 			{TypeAndEventIdx: uint64(graph.ADD), SrcRaw: graph.AsRawType(1), DstRaw: graph.AsRawType(4)},
 			{TypeAndEventIdx: uint64(graph.ADD), SrcRaw: graph.AsRawType(2), DstRaw: graph.AsRawType(0)},
 			{TypeAndEventIdx: uint64(graph.ADD), SrcRaw: graph.AsRawType(2), DstRaw: graph.AsRawType(1)},
@@ -125,7 +125,7 @@ func DynamicWithDelete(undirected bool, t *testing.T) {
 	for tCount := 0; tCount < 10; tCount++ {
 		THREADS := uint32(rand.Intn(8-1) + 1)
 
-		rawTestGraph := []graph.TopologyEvent[EdgeProperty]{
+		rawTestGraph := []graph.InputEvent[EdgeProperty]{
 			{TypeAndEventIdx: uint64(graph.ADD), SrcRaw: graph.AsRawType(1), DstRaw: graph.AsRawType(4)},
 			{TypeAndEventIdx: uint64(graph.ADD), SrcRaw: graph.AsRawType(2), DstRaw: graph.AsRawType(0)},
 			{TypeAndEventIdx: uint64(graph.ADD), SrcRaw: graph.AsRawType(2), DstRaw: graph.AsRawType(1)},

--- a/cmd/lp-sssp/sssp_test.go
+++ b/cmd/lp-sssp/sssp_test.go
@@ -72,7 +72,7 @@ func TestDynamicCreation(t *testing.T) {
 		basicEdge := EdgeProperty{}
 		basicEdge.Weight = 1.0
 
-		rawTestGraph := []graph.TopologyEvent[EdgeProperty]{
+		rawTestGraph := []graph.InputEvent[EdgeProperty]{
 			{TypeAndEventIdx: uint64(graph.ADD), SrcRaw: graph.AsRawType(1), DstRaw: graph.AsRawType(4), EdgeProperty: basicEdge},
 			{TypeAndEventIdx: uint64(graph.ADD), SrcRaw: graph.AsRawType(2), DstRaw: graph.AsRawType(0), EdgeProperty: basicEdge},
 			{TypeAndEventIdx: uint64(graph.ADD), SrcRaw: graph.AsRawType(2), DstRaw: graph.AsRawType(1), EdgeProperty: basicEdge},

--- a/cmd/lp-tc/tc.go
+++ b/cmd/lp-tc/tc.go
@@ -93,7 +93,7 @@ func (alg *TC) OnUpdateVertex(g *graph.Graph[VertexProp, EdgeProp, Mail, Note], 
 }
 
 // Function called when an in-edge is first observed at the destination vertex. This happens before the edge is given to the source vertex as an out-edge.
-func (*TC) OnInEdgeAdd(_ *graph.Graph[VertexProp, EdgeProp, Mail, Note], _ *graph.GraphThread[VertexProp, EdgeProp, Mail, Note], dst *graph.Vertex[VertexProp, EdgeProp], dstProp *VertexProp, _ uint32, pos uint32, topEvent *graph.TopologyEvent[EdgeProp]) {
+func (*TC) OnInEdgeAdd(_ *graph.Graph[VertexProp, EdgeProp, Mail, Note], _ *graph.GraphThread[VertexProp, EdgeProp, Mail, Note], dst *graph.Vertex[VertexProp, EdgeProp], dstProp *VertexProp, _ uint32, pos uint32, topEvent *graph.InputEvent[EdgeProp]) {
 	if topEvent.DstRaw == topEvent.SrcRaw {
 		topEvent.EdgeProperty.Raw = EMPTY // Self edge. For this algorithm, we discard these. (Note this creates a "hole" in the edges.)
 	} else if _, in := dstProp.MapEdgesToPos[topEvent.SrcRaw]; !in { // Update my (in) edges, mapping them to their logical position.

--- a/cmd/lp-template/template.go
+++ b/cmd/lp-template/template.go
@@ -122,7 +122,7 @@ func (alg *Template) OnUpdateVertex(g *graph.Graph[VertexProperty, EdgeProperty,
 // Function called when an in-edge is first observed at the destination vertex. This happens before the edge is given to the source vertex as an out-edge.
 // This should not be used to create algorithmic events, as this function can be called in advance (e.g., it may occur before the logical point in time the graph thread is at).
 // This advanced hook should only be used to adjust structural properties of the graph topology -- for example, adjusting the topEvent and the associated edge property.
-func (*Template) OnInEdgeAdd(_ *graph.Graph[VertexProperty, EdgeProperty, Mail, Note], gt *graph.GraphThread[VertexProperty, EdgeProperty, Mail, Note], dst *graph.Vertex[VertexProperty, EdgeProperty], prop *VertexProperty, didx uint32, pos uint32, topEvent *graph.TopologyEvent[EdgeProperty]) {
+func (*Template) OnInEdgeAdd(_ *graph.Graph[VertexProperty, EdgeProperty, Mail, Note], gt *graph.GraphThread[VertexProperty, EdgeProperty, Mail, Note], dst *graph.Vertex[VertexProperty, EdgeProperty], prop *VertexProperty, didx uint32, pos uint32, topEvent *graph.InputEvent[EdgeProperty]) {
 }
 
 // Function called upon new edge(s) added to the vertex src. This also bundles a visit, including any new mail, from MailRetrieve for this vertex.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ScottSallinen/lollipop
 
-go 1.21
+go 1.22
 
 require (
 	github.com/rs/zerolog v1.29.1

--- a/graph/graph-vertex.go
+++ b/graph/graph-vertex.go
@@ -10,7 +10,7 @@ type Vertex[V VPI[V], E any] struct {
 type VertexStructure struct {
 	PendingIdx  uint64  // Used as offset data for dynamic construction.
 	CreateEvent uint64  // Event index of the first event that created this vertex.
-	InEventPos  uint32  // Used to calculate Pos for new in edges. Pro tip: this position is constant across executions (for the pos of the raw vertex that has an event to me), however note said vertex may have a different internal ID across executions.
+	InEventPos  uint32  // Used to calculate Pos for new in edges. This position is constant across executions (for the pos of the raw vertex that has an event to me).
 	RawId       RawType // Raw (external) ID of the vertex. Pro tip: this is constant across executions. Internal IDs that graph threads choose for a given raw is NOT.
 }
 

--- a/graph/oracle-compare.go
+++ b/graph/oracle-compare.go
@@ -20,7 +20,7 @@ func CompareToOracle[V VPI[V], E EPI[E], M MVI[M], N any, A Algorithm[V, E, M, N
 	}
 
 	if syncWithQuery { // Wait for all threads to sync to match the query before comparing to oracle
-		g.Broadcast(TOP_SYNC)
+		g.Broadcast(EVENT_SYNC)
 		g.AwaitAck()
 	}
 	if broadcast {

--- a/graph/run-dynamic.go
+++ b/graph/run-dynamic.go
@@ -76,13 +76,13 @@ func (g *Graph[V, E, M, N]) PrintEventRate(exit *bool) {
 
 		if g.Options.DebugLevel >= 2 {
 			loopTimes := g.GraphThreads[0].LoopTimes
-			log.Trace().Msg(", recv_cmd, " + utils.F("%0.2f", loopTimes[0].Seconds()*1000) +
-				", remit, " + utils.F("%0.2f", loopTimes[1].Seconds()*1000) +
-				", recv_top, " + utils.F("%0.2f", loopTimes[2].Seconds()*1000) +
-				", apply_top, " + utils.F("%0.2f", loopTimes[3].Seconds()*1000) +
-				", apply_msg, " + utils.F("%0.2f", loopTimes[4].Seconds()*1000) +
-				", backoff_top, " + utils.F("%0.2f", loopTimes[5].Seconds()*1000) +
-				", backoff_msg, " + utils.F("%0.2f", loopTimes[6].Seconds()*1000))
+			log.Trace().Msg(", recv_cmd, " + utils.F("%0.2f", loopTimes[RECV_CMD].Seconds()*1000) +
+				", remit, " + utils.F("%0.2f", loopTimes[REMIT].Seconds()*1000) +
+				", recv_top, " + utils.F("%0.2f", loopTimes[RECV_TOP].Seconds()*1000) +
+				", apply_top, " + utils.F("%0.2f", loopTimes[APPLY_TOP].Seconds()*1000) +
+				", apply_msg, " + utils.F("%0.2f", loopTimes[APPLY_MSG].Seconds()*1000) +
+				", backoff_top, " + utils.F("%0.2f", loopTimes[BACKOFF_TOP].Seconds()*1000) +
+				", backoff_msg, " + utils.F("%0.2f", loopTimes[BACKOFF_ALG].Seconds()*1000))
 		}
 
 		if g.Options.DebugLevel >= 3 || g.Options.Profile {
@@ -95,7 +95,7 @@ func (g *Graph[V, E, M, N]) PrintEventRate(exit *bool) {
 	}
 }
 
-func (gt *GraphThread[V, E, M, N]) checkCommandsDynamic(blockTop, topSync, blockAlgIfTop, epoch *bool) {
+func (gt *GraphThread[V, E, M, N]) checkCommandsDynamic(blockTop, eventSync, blockAlgIfEvents, epoch *bool) {
 	switch <-gt.Command {
 	case BLOCK_ALL:
 		gt.Response <- ACK
@@ -103,20 +103,20 @@ func (gt *GraphThread[V, E, M, N]) checkCommandsDynamic(blockTop, topSync, block
 		if resp != RESUME {
 			log.Panic().Msg("Expected to resume after blocked")
 		}
-	case BLOCK_TOP:
+	case BLOCK_EVENTS:
 		*blockTop = true
 		gt.Response <- ACK
-	case BLOCK_TOP_ASYNC:
+	case BLOCK_EVENTS_ASYNC:
 		*blockTop = true
 		// No ack needed.
 	case RESUME:
 		*blockTop = false
 		// No ack needed.
-	case BLOCK_ALG_IF_TOP:
-		*blockAlgIfTop = true
+	case BLOCK_ALG_IF_EVENTS:
+		*blockAlgIfEvents = true
 		// Init command, no ack needed.
-	case TOP_SYNC:
-		*topSync = true
+	case EVENT_SYNC:
+		*eventSync = true
 		// We will ack later, after we have processed events.
 	case EPOCH:
 		*epoch = true
@@ -126,164 +126,221 @@ func (gt *GraphThread[V, E, M, N]) checkCommandsDynamic(blockTop, topSync, block
 
 // The main loop (e.g., state machine) for a single thread.
 func ConvergeDynamicThread[EP EPP[E], V VPI[V], E EPI[E], M MVI[M], N any, A Algorithm[V, E, M, N]](alg A, g *Graph[V, E, M, N], tidx uint32, wg *sync.WaitGroup, doneEvents chan struct{}, doneRemit chan struct{}) {
-	completed := false   // True indicates the algorithm is done (termination detected).
-	strucClosed := false // True indicates the TopologyEvents channel is closed
-	remitClosed := false // True indicates the Remitter StructureChanges channel is closed
-	gt := &g.GraphThreads[tidx]
+	runtime.LockOSThread()
 
-	_, checkSuperStep := any(alg).(AlgorithmOnSuperStepConverged[V, E, M, N])
-	makeTimeseries := (g.Options.LogTimeseries)
-	insDelOnExpire := g.Options.InsertDeleteOnExpire
-	pullUpToBase := uint64(BASE_SIZE)
+	completed := false   // True indicates the algorithm is done (termination detected).
+	inputClosed := false // True indicates events (input emitted) are done.
+	remitClosed := false // True indicates no more events will be remitted.
+	//remitFailed := false // True indicates a remit failed.
 	blockTop := false
-	topSync := false
-	blockAlgIfTop := false
+	eventSync := false
+	blockAlgIfEvents := false
 	epoch := false
-	var ok bool
-	topCount := uint64(0)
-	algCount := uint64(0)
+	wantsQueryNow := false
+	wantsAsyncQueryNow := false
+	prevMismatch := false
+	undirected := g.Options.Undirected
+	makeTimeseries := (g.Options.LogTimeseries)
+	_, checkSuperStep := any(alg).(AlgorithmOnSuperStepConverged[V, E, M, N])
+
+	gt := &g.GraphThreads[tidx]
+	insDelOnExpire := g.Options.InsertDeleteOnExpire
+
+	pullUpToBase := uint64(BASE_SIZE) * 2
+	algMessageCount := uint64(0)
+	algMessageForHeight := uint64(0)
+
 	remitCount := uint64(0)
+	remitTotalCount := uint64(0)
+
+	largest := uint64(0)
+	currLargest := uint64(0)
+
+	eventsHeight := uint64(0)
+	eventsApplyCountNow := uint64(0)
+	eventsTotalCount := uint64(0)
+	eventsFlushedUpTo := uint64(0)
 	algFail := 0
 	topFail := 0
-	timeStates := g.Options.DebugLevel >= 2
-	if timeStates {
-		gt.LoopTimes = make([]time.Duration, DONE)
-	}
-	runtime.LockOSThread()
-	var onInEdgeAddFunc func(*Graph[V, E, M, N], *GraphThread[V, E, M, N], *Vertex[V, E], *V, uint32, uint32, *TopologyEvent[E])
+
+	loopsFail := 0
+	loopsThrough := 0
+
+	var onInEdgeAddFunc func(*Graph[V, E, M, N], *GraphThread[V, E, M, N], *Vertex[V, E], *V, uint32, uint32, *InputEvent[E])
 	if aIN, ok := any(alg).(AlgorithmOnInEdgeAdd[V, E, M, N]); ok {
 		onInEdgeAddFunc = aIN.OnInEdgeAdd
 	}
 
-	var prev, curr time.Time
-
-	for !completed {
-		if timeStates && tidx == 0 {
-			prev = time.Now()
-		}
-		if len(gt.Command) > 0 {
-			gt.Status = RECV_CMD
-			gt.checkCommandsDynamic(&blockTop, &topSync, &blockAlgIfTop, &epoch)
-		}
-		if timeStates && tidx == 0 {
+	timeStates := func() {}
+	if (g.Options.DebugLevel >= 2) && tidx == 0 {
+		var prev, curr time.Time
+		gt.LoopTimes = make([]time.Duration, DONE)
+		timeStates = func() {
 			curr = time.Now()
-			gt.LoopTimes[0] += curr.Sub(prev)
+			gt.LoopTimes[gt.Status] += curr.Sub(prev)
 			prev = curr
 		}
+		prev = time.Now()
+	}
 
-		if !epoch && !remitClosed && !blockTop {
+	for !completed {
+		if len(gt.Command) > 0 {
+			gt.Status = RECV_CMD
+			gt.checkCommandsDynamic(&blockTop, &eventSync, &blockAlgIfEvents, &epoch)
+		}
+		timeStates()
+
+		processAlg := inputClosed || !(EVENTS_FIRST || blockAlgIfEvents)
+		algMessageHeightChanged := false
+		if processAlg && !prevMismatch {
+			// Receive algorithmic messages; before topology events, to avoid messages that could be over topology that we have not yet processed.
+			if messageCountNew := ReceiveMessages(alg, g, gt, algMessageCount); messageCountNew > algMessageCount {
+				algMessageCount = messageCountNew
+				algMessageHeightChanged = true
+			}
+		}
+		eventsHeight = gt.FromRemitQueue.Height()
+		if algMessageHeightChanged {
+			algMessageForHeight = eventsHeight
+		}
+
+		if !epoch && !remitClosed && !blockTop && !wantsQueryNow && !wantsAsyncQueryNow {
 			gt.Status = REMIT
-			remitClosed, remitCount = checkToRemit(alg, g, gt, onInEdgeAddFunc)
+			remitClosed, remitCount, currLargest, _, wantsQueryNow = checkToRemit(alg, g, gt, onInEdgeAddFunc, eventsFlushedUpTo)
+			largest = utils.Max(largest, currLargest)
 			gt.EventActions += remitCount
+			remitTotalCount += remitCount
 			if remitClosed {
 				//log.Debug().Msg("T[" + utils.F("%02d", tidx) + "] FromEmitEvents closed")
-				remitCount = 0
-				gt.ToRemitQueue.Close()
 				gt.FromEmitQueue.End()
 				doneRemit <- struct{}{}
 			}
-			if timeStates && tidx == 0 {
-				curr = time.Now()
-				gt.LoopTimes[1] += curr.Sub(prev)
-				prev = curr
+
+			if wantsQueryNow { // Did we JUST receive a request for query?
+				// First, this thread needs to acknowledge we saw the query.
+				gt.Response <- ACK
+				<-gt.Command // BLOCK and wait for resume (So all threads confirmed they have seen the query, and all threads must have emplaced their remits to us).
+
+				if g.Options.NoConvergeForQuery {
+					wantsQueryNow = false
+					wantsAsyncQueryNow = true
+				}
 			}
+			timeStates()
 		} else {
 			remitCount = 0
 		}
 
-		processAlg := strucClosed || !(TOPOLOGY_FIRST || blockAlgIfTop)
-		if processAlg {
-			// Receive algorithmic messages; before topology events, to avoid messages that could be over topology that we have not yet processed.
-			algCount = ReceiveMessages[V, E, M, N](alg, g, gt, algCount)
-		}
-
-		// The main check for updates to topology. This occurs with priority over algorithmic messages.
-		processTop := !strucClosed && !blockTop
+		// The main check for updates from events. This occurs with priority over algorithmic messages.
+		processTop := !inputClosed && !blockTop
 		topFailed := false
 		if processTop {
 			gt.Status = RECV_TOP
-			for topCount = 0; topCount < pullUpToBase; topCount++ {
-				gt.TopologyEventBuff[topCount], ok = gt.TopologyQueue.Accept()
-				if !ok {
-					if gt.TopologyQueue.IsClosed() {
-						//log.Debug().Msg("T[" + utils.F("%02d", tidx) + "] TopologyQueue closed")
-						strucClosed = true
-						gt.TopologyQueue.End()
+
+			if remitClosed && remitTotalCount == eventsTotalCount && gt.FromEmitQueue.IsClosed() {
+				inputClosed = true
+				gt.TopologyEventBuff = nil
+				gt.VertexPendingBuff = nil
+				doneEvents <- struct{}{}
+				gt.FromRemitQueue.End()
+			}
+
+			prevMismatch = false
+			for eventsApplyCountNow = 0; remitTotalCount > eventsTotalCount; eventsApplyCountNow++ {
+				if remitEvent, ok := gt.FromRemitQueue.Accept(); !ok {
+					if eventsTotalCount < algMessageForHeight {
+						processAlg = false
+						prevMismatch = true
+						loopsFail++
 					}
+					//log.Info().Msg("T[" + utils.F("%02d", tidx) + "] events Gap In Order")
 					break
+				} else {
+					eventsTotalCount++
+					targetIndex := remitEvent.Order - eventsFlushedUpTo
+					gt.TopologyEventBuff[targetIndex].Edge = remitEvent.Edge // They told us the edge.
 				}
 			}
+			timeStates()
 
-			if timeStates && tidx == 0 {
-				curr = time.Now()
-				gt.LoopTimes[2] += curr.Sub(prev)
-				prev = curr
-			}
-
-			// Apply any topology events that we have pulled.
-			if topCount != 0 {
-				gt.EventActions += uint64(topCount)
+			// Apply any events that we have pulled.
+			if eventsApplyCountNow != 0 {
 				gt.Status = APPLY_TOP
-				addEvents, delEvents := EnactTopologyEvents[EP](alg, g, gt, topCount, insDelOnExpire)
+				addEvents, delEvents := EnactTopologyEvents[EP](alg, g, gt, eventsApplyCountNow, insDelOnExpire, undirected)
 				gt.NumOutAdds += addEvents
 				gt.NumOutDels += delEvents
 				gt.NumEdges += addEvents - delEvents
 
-				if timeStates && tidx == 0 {
-					curr = time.Now()
-					gt.LoopTimes[3] += curr.Sub(prev)
-					prev = curr
-				}
+				//log.Info().Msg("T[" + utils.F("%02d", tidx) + "] eventsApplyCountNow " + utils.V(eventsApplyCountNow) + " remitCount " + utils.V(remitCount))
+
+				// shuffle down the event buffer
+				copy(gt.TopologyEventBuff, gt.TopologyEventBuff[eventsApplyCountNow:(largest-eventsFlushedUpTo)+1])
+				eventsFlushedUpTo += eventsApplyCountNow
+				gt.EventActions += eventsApplyCountNow
+
+				timeStates()
 
 				// If we filled bundle then we loop back to ingest more events, rather than process algorithm messages, as the thread is behind.
-				if (topCount == pullUpToBase) || topSync {
+				if (eventsApplyCountNow >= uint64(len(gt.TopologyEventBuff)/2)) || eventSync {
 					if uint64(gt.NumEdges)/(64) > pullUpToBase {
 						pullUpToBase = pullUpToBase * 2
 						if len(gt.TopologyEventBuff) < int(pullUpToBase) {
-							gt.TopologyEventBuff = make([]RawEdgeEvent[E], pullUpToBase)
+							gt.TopologyEventBuff = append(gt.TopologyEventBuff, make([]RawEdgeEvent[E], pullUpToBase)...)
+							log.Info().Msg("T[" + utils.F("%02d", tidx) + "] increasing buffer size to " + utils.V(len(gt.TopologyEventBuff)))
 						}
-						log.Debug().Msg("T[" + utils.F("%02d", tidx) + "] increasing buffer size to " + utils.V(pullUpToBase))
-					}
-					if strucClosed {
-						doneEvents <- struct{}{}
 					}
 					continue
 				} else if makeTimeseries {
-					if strucClosed {
-						doneEvents <- struct{}{}
-					}
 					continue
 				}
-			} else if topSync && remitCount == 0 {
-				// There is a request for syncing topology (blocking), acknowledge here as we have no more topology events to process.
-				topSync = false
+			} else if eventSync && remitCount == 0 {
+				// There is a request for syncing topology (blocking), acknowledge here as we have no more events to process.
+				eventSync = false
 				gt.Response <- ACK
 			} else if remitCount == 0 && !epoch {
 				topFailed = true
 			}
+		}
 
-			if strucClosed {
-				gt.TopologyEventBuff = nil
-				gt.VertexPendingBuff = nil
-				doneEvents <- struct{}{}
-			}
+		if wantsAsyncQueryNow { // This type of query is more of a "sample", since it does not wait for convergence.
+			// We applied available events, so we are good to report continuation.
+			gt.Response <- ACK
+			wantsAsyncQueryNow = false
+			blockTop = true // We will block further topology until we receive the resume command.
+			// TODO: Check for g.Options.AllowAsyncVertexProps , need to adjust for this.
 		}
 
 		algFailed := false
 		if processAlg {
+			if processTop {
+				loopsThrough++
+			}
 			// Process algorithm messages. Check for algorithm termination if needed.
 			gt.Status = APPLY_MSG
-			checkTerm := (strucClosed && remitClosed) || // all topology events are done, or
-				(blockTop && checkSuperStep) || // topology events are currently blocked and we may super-step, (NoConvergeForQuery blocks top, would not have super-steps, but might complete)
-				(epoch && topCount == 0) // no more topology events in this epoch (assuming the remitter does not produce new events after it starts an epoch)
-			completed = ProcessMessages[V, E, M, N](alg, g, gt, algCount, checkTerm)
-			if !completed && algCount == 0 {
+			checkTerm := (inputClosed && remitClosed) || // all events are done, or
+				(blockTop && checkSuperStep) || // events are currently blocked and we may super-step, (NoConvergeForQuery blocks top, would not have super-steps, but might complete)
+				(epoch && eventsApplyCountNow == 0) || // no more events in this epoch (assuming the remitter does not produce new events after it starts an epoch)
+				(wantsQueryNow && eventsApplyCountNow == 0) // no more events, and we are ready to query
+			completed = ProcessMessages(alg, g, gt, algMessageCount, checkTerm)
+			if !completed && algMessageCount == 0 {
 				algFailed = true
 			}
-			algCount = 0
+			algMessageCount = 0
 
 			if completed && checkSuperStep {
-				completed = AwaitSuperStepConvergence[V, E, M, N](alg, g, tidx)
+				completed = AwaitSuperStepConvergence(alg, g, tidx)
+			}
+			if completed && wantsQueryNow {
+				gt.Status = DONE
+				gt.Response <- ACK // This is a second ack, the first was when we saw the request for query.
+
+				resp := <-gt.Command // BLOCK and wait for resume
+				if resp != RESUME {
+					log.Panic().Msg("Expected to resume after blocked")
+				}
+				wantsQueryNow = false
+				completed = false
+				topFail, algFail = 0, 0
 			}
 			if completed && epoch {
 				//log.Debug().Msg("T[" + utils.F("%02d", tidx) + "] completed epoch")
@@ -300,20 +357,17 @@ func ConvergeDynamicThread[EP EPP[E], V VPI[V], E EPI[E], M MVI[M], N any, A Alg
 			}
 			if completed && blockTop {
 				completed = false
-				log.Panic().Msg("Algorithm terminated when topology events are blocked")
+				log.Panic().Msg("Algorithm terminated when events are blocked")
 			}
+			timeStates()
 		}
 
-		// Backoff only when there are no topological events and algorithmic event
+		// Backoff only when there are no topological events OR algorithm messages
 		if (!processTop || topFailed) && (!processAlg || algFailed) {
 			if topFailed {
 				gt.Status = BACKOFF_TOP
 				utils.BackOff(topFail)
-				if timeStates && tidx == 0 {
-					curr = time.Now()
-					gt.LoopTimes[5] += curr.Sub(prev)
-					prev = curr
-				}
+				timeStates()
 				topFail++
 			} else {
 				topFail = 0
@@ -322,11 +376,7 @@ func ConvergeDynamicThread[EP EPP[E], V VPI[V], E EPI[E], M MVI[M], N any, A Alg
 				if algFail%10 == 0 {
 					gt.Status = BACKOFF_ALG
 					utils.BackOff(algFail / 10)
-					if timeStates && tidx == 0 {
-						curr = time.Now()
-						gt.LoopTimes[6] += curr.Sub(prev)
-						prev = curr
-					}
+					timeStates()
 				}
 				algFail++
 			} else {
@@ -335,15 +385,9 @@ func ConvergeDynamicThread[EP EPP[E], V VPI[V], E EPI[E], M MVI[M], N any, A Alg
 		} else {
 			topFail, algFail = 0, 0
 		}
-
-		if timeStates && tidx == 0 {
-			curr = time.Now()
-			gt.LoopTimes[4] += curr.Sub(prev)
-			prev = curr
-		}
 	}
+	log.Debug().Msg("T[" + utils.F("%02d", tidx) + "] loopsThrough " + utils.V(loopsThrough) + " loopsFail " + utils.V(loopsFail))
 	gt.Status = DONE
-	//log.Debug().Msg("T[" + utils.F("%02d", tidx) + "] done")
 	wg.Done()
 	runtime.UnlockOSThread()
 }
@@ -377,6 +421,9 @@ func ConvergeDynamic[EP EPP[E], V VPI[V], E EPI[E], M MVI[M], N any, A Algorithm
 		<-doneRemit
 	}
 	log.Debug().Msg("Seen acknowledge of done remits after (ms) " + utils.V(g.Watch.Elapsed().Milliseconds()))
+	for t := 0; t < int(THREADS); t++ {
+		g.GraphThreads[t].FromRemitQueue.Close()
+	}
 
 	// Wait for all events to be consumed.
 	for i := 0; i < int(THREADS); i++ {

--- a/graph/stream-parse.go
+++ b/graph/stream-parse.go
@@ -74,8 +74,8 @@ func AsRawTypeString(val string) RawType {
 // TODO: how to choose between options in a clean way?
 
 // [src dst] , implying add only
-func EdgeParser[E EPI[E]](stringFields []string) (TopologyEvent[E], []string) {
-	return TopologyEvent[E]{
+func EdgeParser[E EPI[E]](stringFields []string) (InputEvent[E], []string) {
+	return InputEvent[E]{
 		TypeAndEventIdx: uint64(ADD),
 		SrcRaw:          AsRawTypeString(stringFields[0]),
 		DstRaw:          AsRawTypeString(stringFields[1]),

--- a/graph/stream_test.go
+++ b/graph/stream_test.go
@@ -22,7 +22,7 @@ type MyEdge struct {
 }
 
 func Benchmark_Load_RB_Bufio(b *testing.B) {
-	edgeQueue := new(utils.RingBuffSPSC[TopologyEvent[MyEdge]])
+	edgeQueue := new(utils.RingBuffSPSC[InputEvent[MyEdge]])
 	edgeQueue.Init(uint64(target))
 	go discardInput(edgeQueue)
 
@@ -38,7 +38,7 @@ func Benchmark_Load_RB_Bufio(b *testing.B) {
 }
 
 func Benchmark_Load_RB_Scan(b *testing.B) {
-	edgeQueue := new(utils.RingBuffSPSC[TopologyEvent[MyEdge]])
+	edgeQueue := new(utils.RingBuffSPSC[InputEvent[MyEdge]])
 	edgeQueue.Init(uint64(target))
 	go discardInput(edgeQueue)
 
@@ -78,7 +78,7 @@ func Benchmark_Load_Zenq_Scan(b *testing.B) {
 
 // Why so slow?
 func Benchmark_Load_Chan_Scan(b *testing.B) {
-	edgeQueue := make(chan TopologyEvent[MyEdge], (uint32(target)))
+	edgeQueue := make(chan InputEvent[MyEdge], (uint32(target)))
 	go discardInputChan(edgeQueue)
 
 	file := utils.OpenFile(fileName)
@@ -94,8 +94,8 @@ func Benchmark_Load_Chan_Scan(b *testing.B) {
 	file.Close()
 }
 
-func stream_RB_bufio[EP EPP[E], E EPI[E]](scanner *bufio.Scanner, edgeQueue *utils.RingBuffSPSC[TopologyEvent[E]], n int) (lines uint64) {
-	var sc TopologyEvent[E]
+func stream_RB_bufio[EP EPP[E], E EPI[E]](scanner *bufio.Scanner, edgeQueue *utils.RingBuffSPSC[InputEvent[E]], n int) (lines uint64) {
+	var sc InputEvent[E]
 	var b []byte
 	fields := make([]string, MAX_ELEMS_PER_EDGE)
 
@@ -118,8 +118,8 @@ func stream_RB_bufio[EP EPP[E], E EPI[E]](scanner *bufio.Scanner, edgeQueue *uti
 	return lines
 }
 
-func stream_RB_scan[EP EPP[E], E EPI[E]](file *os.File, s *utils.FastFileLines, edgeQueue *utils.RingBuffSPSC[TopologyEvent[E]], n int) (lines uint64) {
-	var sc TopologyEvent[E]
+func stream_RB_scan[EP EPP[E], E EPI[E]](file *os.File, s *utils.FastFileLines, edgeQueue *utils.RingBuffSPSC[InputEvent[E]], n int) (lines uint64) {
+	var sc InputEvent[E]
 	var b []byte
 	fields := make([]string, MAX_ELEMS_PER_EDGE)
 
@@ -146,8 +146,8 @@ func stream_RB_scan[EP EPP[E], E EPI[E]](file *os.File, s *utils.FastFileLines, 
 	return lines
 }
 
-func stream_chan_scan[EP EPP[E], E EPI[E]](file *os.File, s *utils.FastFileLines, edgeQueue chan TopologyEvent[E], n int) (lines uint64) {
-	var sc TopologyEvent[E]
+func stream_chan_scan[EP EPP[E], E EPI[E]](file *os.File, s *utils.FastFileLines, edgeQueue chan InputEvent[E], n int) (lines uint64) {
+	var sc InputEvent[E]
 	var b []byte
 	fields := make([]string, MAX_ELEMS_PER_EDGE)
 
@@ -206,13 +206,13 @@ func discardInputZenq(edgeQueue *zenq.ZenQ[TopologyEvent[MyEdge]]) {
 }
 */
 
-func discardInputChan(edgeQueue chan TopologyEvent[MyEdge]) {
+func discardInputChan(edgeQueue chan InputEvent[MyEdge]) {
 	for range edgeQueue {
 		// do nothing
 	}
 }
 
-func discardInput(edgeQueue *utils.RingBuffSPSC[TopologyEvent[MyEdge]]) {
+func discardInput(edgeQueue *utils.RingBuffSPSC[InputEvent[MyEdge]]) {
 	retried := 0
 	totalRetried := 0
 	var ok bool

--- a/utils/bitmap_test.go
+++ b/utils/bitmap_test.go
@@ -148,7 +148,7 @@ func Test_FindFirstUnused(t *testing.T) {
 	}
 }
 
-func assertEqual(t *testing.T, expected any, actual any, prefix string) {
+func assertEqual(_ *testing.T, expected any, actual any, prefix string) {
 	if reflect.DeepEqual(expected, actual) {
 		return
 	}


### PR DESCRIPTION
This is the updated design of the Emitter, where it emits to both source and destination asynchronously. The source and destination then remit to the other. In this design, performance with directed graphs is still quite good, and undirected graphs can see a significant boost in performance.

Further, this design offers far more stable guarantees for vertex creation: vertexes are now always created in temporal order within a graph thread (i.e., they are sorted by first observation, regardless of if the first observation was from some other graph thread creating a new edge to a vertex that didn't exist yet.)

The resultant graph structure is now fully deterministic, and everything is sorted by total global ordering 🎉 